### PR TITLE
Self mention

### DIFF
--- a/emotes/command_operations.py
+++ b/emotes/command_operations.py
@@ -8,7 +8,7 @@ import json
 import discord
 from config.config import CONTRIBUTORS_FILE_PATH
 from shared.helpers import get_guild_member_check_role
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 
 async def add_contributor_to_list(
@@ -241,7 +241,7 @@ async def add_contributor(
             if server_contributors is None:
                 await ctx.send("No contributors found for server: " + ctx.guild.name)
                 return
-            existing_contributor: [Dict[str, str], None] = next(
+            existing_contributor: Optional[Dict[str, str]] = next(
                 (c for c in server_contributors if c["uid"] == uid), None
             )
 
@@ -270,7 +270,8 @@ async def add_contributor(
         if server_contributors is None:
             await ctx.send("No contributors found for server: " + ctx.guild.name)
             return
-        existing_contributor: [Dict[str, str], None] = next(
+        existing_contributor: Optional[Dict[str, str]] = next(
+
             (c for c in server_contributors if c["uid"] == uid), None
         )
 

--- a/shared/event_operations.py
+++ b/shared/event_operations.py
@@ -155,7 +155,7 @@ async def handle_reaction(
             (c for c in contributors if c["uid"] == emoji_dicts[contributor_emoji]),
             None,
         )
-        if contributor:
+        if contributor and str(contributor["uid"]) != str(user.id):  # Check if the user who reacted is not the contributor
             message_link = reaction.message.jump_url
             logger.info("Emoji react found, DMing contributor")
             await send_dm_once(bot, contributor, message_link)

--- a/shared/event_operations.py
+++ b/shared/event_operations.py
@@ -91,7 +91,7 @@ async def handle_message(
         )
         if emoji_id in message.content:
             logger.info("Emoji Found in message! %s", emoji_id)
-            if contributor:
+            if contributor and str(contributor["uid"]) != str(message.author.id):  # Convert both IDs to strings before comparing
                 try:
                     logger.info(f'Messaging the user, {contributor["uid"]}')
                     message_link = message.jump_url


### PR DESCRIPTION
Updated type annotation due to warning.

Bot will no longer DM if a contributor uses their own emoji (in a message, or as a reaction to a message)