### PR TITLE
Remove bot.process_commands(message)

### DIFF
--- a/shared/event_operations.py
+++ b/shared/event_operations.py
@@ -89,9 +89,6 @@ async def handle_message(
                     await send_dm_once(bot, contributor, message_link)
                 except discord.errors.NotFound:
                     logger.warning(f'User not found: {contributor["uid"]}')
-    # Process commands
-    await bot.process_commands(message)
-
 
 async def handle_reaction(
     bot: commands.Bot,


### PR DESCRIPTION
Removed processing of bot commands.
Noticed that bot was interpreting all messages as commands after removing the command prefix.