### PR TITLE
Config ID increment in docker-compose

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -13,7 +13,7 @@ ONGOING_VOTES_FILE_PATH = "./data/ongoing_votes.json"
 
 # Load configuration
 config: configparser.ConfigParser = configparser.ConfigParser()
-config.read("config/config.ini")
+config.read(CONFIG_ABSOLUTE_PATH)
 
 current_governance_id: int = config.getint("ID_START_VALUES", "governance_id")
 current_budget_id: int = config.getint("ID_START_VALUES", "budget_id")
@@ -44,9 +44,8 @@ def increment_config_id(
         raise ValueError(err_msg)
 
     key = CONFIG_ID_MAP[id_type]
-    config["ID_START_VALUES"][key] = str(
-        int(config["ID_START_VALUES"][key]) + increment
-    )
+    new_value = int(config["ID_START_VALUES"][key]) + increment
+    config["ID_START_VALUES"][key] = str(new_value)
 
     try:
         with open(CONFIG_ABSOLUTE_PATH, "w") as f:


### PR DESCRIPTION
**What changed**

- setting new value prior to converting, allows for easier inspection of value in debugging before incrementing
- use defined path for config.read 

**How to test**

- Start bot
- Create and publish a proposal
- validate increment in container

