### PR TITLE
Use fallback RPC + retry, updated .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 DISCORD_BOT_TOKEN=MTEzMjYzMgY
 ETH_ADDRESS=0xsdfsdf343
 ETH_PRIVATE_KEY=0x534j23dgf
+PRIMARY_RPC=https://ethereum-sepolia-rpc.publicnode.com
+SECONDARY_RPC=https://rpc.sepolia.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- RPC Fallback and timeout to navigate some client errors that may occur
+
 - handling if optional textInputs are empty
 
 - Added helper function to retrieve snapshot URL to include in a discord announcement & thread for easier access to the live vote.


### PR DESCRIPTION
**What's New**
- Updated .env.example to reflect examples of env vars that need to be set
- Fallback RPC usage in the event the proposal submission errors
- 3x Retry (exponentially from initial time of 5 seconds) 


**How to test**
Set .envs
Update constants
Update yes_count in tasks.py to 0 or 1 (1 if you will vote on posts)
Set URL to testnet.hub.xx in helpers.py
^^ This will be changed in the future so one can simply set a var to true / false for example to alternate between mainnet and sepolia, aware that this is clunky and not ideal atm.


