### PR TITLE
Gov type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,12 @@ All commands use discords slash commands (/)
 
 ```/vote_draft``` 
 
-Upon typing the command the bot will present you with three buttons: Create, Edit, Preview, and Delete. 
+Upon typing the command, the bot will present you with four buttons: "Create", "Edit", "Preview", and "Delete".
 
-These should be self explained, clicking create will prompt you with either general or budget, these options dictate the type of proposal. Edit will allow you to edit an existing proposal, and delete
-will let you delete an existing proposal that has not yet been published. 
+"Create" will create a new proposal.
+"Edit" will allow you to select an an existing proposal to edit.
+"Preview" will allow you to preview an existing proposal before it is published.
+"Delete" will allow you delete and existing proposal that has not been published.
 
 You can use this command repeatedly to perform different actions if necessary.
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ All commands use discords slash commands (/)
 
 ```/vote_draft``` 
 
-Upon typing the command the bot will present you with three buttons: Create, Edit, Delete.
+Upon typing the command the bot will present you with three buttons: Create, Edit, Preview, and Delete. 
 
-These should be self explained, create will allow you to draft a proposal. Edit will allow you to edit an existing proposal, and delete
+These should be self explained, clicking create will prompt you with either general or budget, these options dictate the type of proposal. Edit will allow you to edit an existing proposal, and delete
 will let you delete an existing proposal that has not yet been published. 
 
 You can use this command repeatedly to perform different actions if necessary.

--- a/proposals/proposal_buttons_view.py
+++ b/proposals/proposal_buttons_view.py
@@ -12,12 +12,14 @@ class ProposalButtonsView(discord.ui.View):
         super().__init__()
         self.proposals = proposals
 
-    @discord.ui.button(label="Create", style=discord.ButtonStyle.green)
-    async def create(self, interaction: discord.Interaction, button: discord.ui.Button):
-        modal = ProposalModal(interaction.channel, None)
-        await interaction.response.send_modal(modal)
+    @discord.ui.button(label="Create Proposal", style=discord.ButtonStyle.green)
+    async def create_proposal(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.clear_items()
+        self.add_item(CreateGeneralProposalButton(self.proposals))
+        self.add_item(CreateBudgetProposalButton(self.proposals))
+        await interaction.response.edit_message(view=self)
 
-    @discord.ui.button(label="Edit", style=discord.ButtonStyle.blurple)
+    @discord.ui.button(label="Edit Proposal", style=discord.ButtonStyle.blurple)
     async def edit(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not self.proposals:
             await interaction.response.send_message(
@@ -28,7 +30,7 @@ class ProposalButtonsView(discord.ui.View):
             self.add_item(EditProposalSelect(self.proposals))
             await interaction.response.edit_message(view=self)
 
-    @discord.ui.button(label="Preview", style=discord.ButtonStyle.grey)
+    @discord.ui.button(label="Preview Proposal", style=discord.ButtonStyle.grey)
     async def preview(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not self.proposals:
             await interaction.response.send_message("No proposals to preview.", ephemeral=True)
@@ -37,8 +39,8 @@ class ProposalButtonsView(discord.ui.View):
             self.add_item(PreviewProposalSelect(self.proposals))
             await interaction.response.edit_message(view=self)
             await interaction.response.send_message(view=self)
- 
-    @discord.ui.button(label="Delete", style=discord.ButtonStyle.red)
+
+    @discord.ui.button(label="Delete Proposal", style=discord.ButtonStyle.red)
     async def delete(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not self.proposals:
             await interaction.response.send_message(
@@ -48,3 +50,23 @@ class ProposalButtonsView(discord.ui.View):
             self.clear_items()
             self.add_item(DeleteProposalSelect(self.proposals))
             await interaction.response.edit_message(view=self)
+
+
+class CreateGeneralProposalButton(discord.ui.Button):
+    def __init__(self, proposals):
+        super().__init__(label="General Proposal", style=discord.ButtonStyle.green)
+        self.proposals = proposals
+
+    async def callback(self, interaction: discord.Interaction):
+        modal = ProposalModal(interaction.channel, None, proposal_type="governance")
+        await interaction.response.send_modal(modal)
+
+
+class CreateBudgetProposalButton(discord.ui.Button):
+    def __init__(self, proposals):
+        super().__init__(label="Budget Proposal", style=discord.ButtonStyle.green)
+        self.proposals = proposals
+
+    async def callback(self, interaction: discord.Interaction):
+        modal = ProposalModal(interaction.channel, None, proposal_type="budget")
+        await interaction.response.send_modal(modal)

--- a/proposals/proposal_buttons_view.py
+++ b/proposals/proposal_buttons_view.py
@@ -4,7 +4,11 @@ ProposalButtonsView is a discord.ui.View that contains buttons for creating, edi
 
 import discord
 from .proposal_modal import ProposalModal
-from .proposal_selects import DeleteProposalSelect, EditProposalSelect, PreviewProposalSelect
+from .proposal_selects import (
+    DeleteProposalSelect,
+    EditProposalSelect,
+    PreviewProposalSelect,
+)
 
 
 class ProposalButtonsView(discord.ui.View):
@@ -13,11 +17,16 @@ class ProposalButtonsView(discord.ui.View):
         self.proposals = proposals
 
     @discord.ui.button(label="Create Proposal", style=discord.ButtonStyle.green)
-    async def create_proposal(self, interaction: discord.Interaction, button: discord.ui.Button):
-        self.clear_items()
-        self.add_item(CreateGeneralProposalButton(self.proposals))
-        self.add_item(CreateBudgetProposalButton(self.proposals))
-        await interaction.response.edit_message(view=self)
+    async def create_proposal(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        view = discord.ui.View()
+        view.add_item(CreateGeneralProposalButton(self.proposals))
+        view.add_item(CreateBudgetProposalButton(self.proposals))
+
+        await interaction.response.send_message(
+            content="Choose a proposal type:", view=view, ephemeral=True
+        )
 
     @discord.ui.button(label="Edit Proposal", style=discord.ButtonStyle.blurple)
     async def edit(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -30,10 +39,14 @@ class ProposalButtonsView(discord.ui.View):
             self.add_item(EditProposalSelect(self.proposals))
             await interaction.response.edit_message(view=self)
 
-    @discord.ui.button(label="Preview Proposal", style=discord.ButtonStyle.grey)
-    async def preview(self, interaction: discord.Interaction, button: discord.ui.Button):
+    @discord.ui.button(label="Preview", style=discord.ButtonStyle.grey)
+    async def preview(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         if not self.proposals:
-            await interaction.response.send_message("No proposals to preview.", ephemeral=True)
+            await interaction.response.send_message(
+                "No proposals to preview.", ephemeral=True
+            )
         else:
             self.clear_items()
             self.add_item(PreviewProposalSelect(self.proposals))

--- a/proposals/proposal_buttons_view.py
+++ b/proposals/proposal_buttons_view.py
@@ -16,7 +16,7 @@ class ProposalButtonsView(discord.ui.View):
         super().__init__()
         self.proposals = proposals
 
-    @discord.ui.button(label="Create Proposal", style=discord.ButtonStyle.green)
+    @discord.ui.button(label="Create", style=discord.ButtonStyle.green)
     async def create_proposal(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
@@ -25,10 +25,10 @@ class ProposalButtonsView(discord.ui.View):
         view.add_item(CreateBudgetProposalButton(self.proposals))
 
         await interaction.response.send_message(
-            content="Choose a proposal type:", view=view, ephemeral=True
+            content="Proposal type:", view=view, ephemeral=True
         )
 
-    @discord.ui.button(label="Edit Proposal", style=discord.ButtonStyle.blurple)
+    @discord.ui.button(label="Edit", style=discord.ButtonStyle.blurple)
     async def edit(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not self.proposals:
             await interaction.response.send_message(
@@ -53,7 +53,7 @@ class ProposalButtonsView(discord.ui.View):
             await interaction.response.edit_message(view=self)
             await interaction.response.send_message(view=self)
 
-    @discord.ui.button(label="Delete Proposal", style=discord.ButtonStyle.red)
+    @discord.ui.button(label="Delete", style=discord.ButtonStyle.red)
     async def delete(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not self.proposals:
             await interaction.response.send_message(
@@ -67,7 +67,7 @@ class ProposalButtonsView(discord.ui.View):
 
 class CreateGeneralProposalButton(discord.ui.Button):
     def __init__(self, proposals):
-        super().__init__(label="General Proposal", style=discord.ButtonStyle.green)
+        super().__init__(label="General", style=discord.ButtonStyle.green)
         self.proposals = proposals
 
     async def callback(self, interaction: discord.Interaction):
@@ -77,7 +77,7 @@ class CreateGeneralProposalButton(discord.ui.Button):
 
 class CreateBudgetProposalButton(discord.ui.Button):
     def __init__(self, proposals):
-        super().__init__(label="Budget Proposal", style=discord.ButtonStyle.green)
+        super().__init__(label="Budget", style=discord.ButtonStyle.green)
         self.proposals = proposals
 
     async def callback(self, interaction: discord.Interaction):

--- a/proposals/proposal_modal.py
+++ b/proposals/proposal_modal.py
@@ -5,7 +5,6 @@ proposal_modal is a discord.ui.Modal that is used to create or edit a proposal. 
 import discord
 from discord import ui
 from proposals.proposals import proposals
-from config import config as cfg
 
 
 class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
@@ -38,7 +37,9 @@ class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
         super().__init__()
         self.channel = channel
         self.proposal = proposal
-        self.proposal_type = proposal_type
+        self.proposal_type = (
+            proposal.get("type") if proposal is not None else proposal_type
+        )
 
         if proposal is not None:
             self.name.default = proposal["title"]
@@ -60,7 +61,6 @@ class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
         member_id: int = interaction.user.id
 
         full_title = self.generate_full_title(self.proposal_type, self.name.value)
-        # Validate title length
         if len(full_title) > 100:
             await interaction.response.send_message(
                 "The total length of the proposal title including prefix exceeds 100 characters. Please shorten your title.",
@@ -68,7 +68,6 @@ class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
             )
             return
 
-        # Check if a proposal with the same name already exists
         if self.proposal is None and any(
             proposal["title"] == self.name.value for proposal in proposals
         ):
@@ -78,7 +77,6 @@ class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
             )
             return
 
-        # Construct the proposal data dictionary
         proposal_data = {
             "member_id": member_id,
             "title": self.name.value,
@@ -89,13 +87,10 @@ class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
         }
 
         if self.proposal is None:
-            # If it's a new proposal, add it to the list
             proposals.append(proposal_data)
         else:
-            # Update existing proposal
             self.proposal.update(proposal_data)
 
-        # Clear the buttons and show the response when a proposal is created/edited
         e = discord.Embed()
         e.title = f"Thank you, proposal has been created/edited. Use the same command to edit the proposal."
         e.description = f"{self.name.value}"

--- a/proposals/proposal_modal.py
+++ b/proposals/proposal_modal.py
@@ -6,16 +6,11 @@ import discord
 from discord import ui
 from proposals.proposals import proposals
 from config import config as cfg
-from consts.types import GOVERNANCE_ID_TYPE, BUDGET_ID_TYPE
 
 
 class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
     name = ui.TextInput(
         label="Proposal title:", style=discord.TextStyle.short, required=True
-    )
-
-    proposal_type = ui.TextInput(
-        label="Proposal type:", style=discord.TextStyle.short, required=True
     )
 
     abstract = ui.TextInput(
@@ -39,14 +34,14 @@ class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
         max_length=2000,
     )
 
-    def __init__(self, channel, proposal):
+    def __init__(self, channel, proposal, proposal_type=None):
         super().__init__()
         self.channel = channel
         self.proposal = proposal
+        self.proposal_type = proposal_type
 
         if proposal is not None:
             self.name.default = proposal["title"]
-            self.proposal_type.default = proposal["type"]
             self.background.default = proposal["background"]
             self.abstract.default = proposal["abstract"]
             self.additional.default = proposal["additional"]
@@ -64,15 +59,7 @@ class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
     async def on_submit(self, interaction: discord.Interaction) -> None:
         member_id: int = interaction.user.id
 
-        # Check if the proposal type is valid
-        if self.proposal_type.value not in [GOVERNANCE_ID_TYPE, BUDGET_ID_TYPE]:
-            await interaction.response.send_message(
-                'Invalid proposal type. It must be either "governance" or "budget".',
-                ephemeral=True,
-            )
-            return
-
-        full_title = self.generate_full_title(self.proposal_type.value, self.name.value)
+        full_title = self.generate_full_title(self.proposal_type, self.name.value)
         # Validate title length
         if len(full_title) > 100:
             await interaction.response.send_message(
@@ -95,7 +82,7 @@ class ProposalModal(ui.Modal, title="Create/Edit Proposal"):
         proposal_data = {
             "member_id": member_id,
             "title": self.name.value,
-            "type": self.proposal_type.value,
+            "type": self.proposal_type,
             "abstract": self.abstract.value,
             "background": self.background.value,
             "additional": self.additional.value,


### PR DESCRIPTION
**Whats new**
- Removed textInput field for proposal type
- Created a button selection option instead
- Removed now redundant error handling of proposal type

This removes the need for:

a - A user to somehow magically *know* the proposal types
b - Error handling / frustration of the wrong type being provided

**How to test**
- docker-compose up --build
- invoke /vote_draft command
- create a proposal

![image](https://github.com/user-attachments/assets/9fbce4b7-d7b4-49bd-a106-fe2b55e07115)

![image](https://github.com/user-attachments/assets/38839a63-ac0d-49ad-84fc-d2a543d66553)
