### PR TITLE
Quorum calc

### DIFF
--- a/snapshot/modify_space.js
+++ b/snapshot/modify_space.js
@@ -19,7 +19,7 @@ const secondaryRpc = process.env.SECONDARY_RPC_URL;
 
 const hub = process.env.SNAPSHOT_HUB;
 const snapshotSpace = process.env.SNAPSHOT_SPACE;
-const network = process.env.NETWORK_ID || '11155111';
+const network = process.env.NETWORK_ID;
 const settingsName = process.env.SETTINGS_NAME;
 const settingsAbout = process.env.SETTINGS_ABOUT;
 const settingsSymbol = process.env.SETTINGS_SYMBOL;

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -48,7 +48,6 @@ class Utils:
         env["SNAPSHOT_HUB"] = cfg.SNAPSHOT_HUB
         env["SNAPSHOT_SPACE"] = cfg.SNAPSHOT_SPACE
         env["NETWORK_ID"] = cfg.NETWORK_ID
-        env["NETWORK"] = cfg.NETWORK_ID
         env["SETTINGS_NAME"] = cfg.SETTINGS_NAME
         env["SETTINGS_ABOUT"] = cfg.SETTINGS_ABOUT
         env["SETTINGS_SYMBOL"] = cfg.SETTINGS_SYMBOL
@@ -180,7 +179,6 @@ class Utils:
             logger.error("Failed to fetch total supply.")
             return None
 
-        # Calculate percentage directly since total_supply is already in ether
         quorum = int((total_supply * percentage) // 100)
         logger.info(f"{percentage}% of the total supply is {quorum}.")
         return quorum

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -47,6 +47,7 @@ class Utils:
         command = ["node", "./snapshot/modify_space.js", str(quorum_value)]
         env["SNAPSHOT_HUB"] = cfg.SNAPSHOT_HUB
         env["SNAPSHOT_SPACE"] = cfg.SNAPSHOT_SPACE
+        env["NETWORK_ID"] = cfg.NETWORK_ID
         env["NETWORK"] = cfg.NETWORK_ID
         env["SETTINGS_NAME"] = cfg.SETTINGS_NAME
         env["SETTINGS_ABOUT"] = cfg.SETTINGS_ABOUT
@@ -129,11 +130,34 @@ class Utils:
                     logger.error("Failed to connect to SECONDARY_RPC")
                     return 0
 
-            contract = w3.eth.contract(
-                address=Web3.to_checksum_address(cfg.XP_CONTRACT_ADDRESS),
-                abi=cfg.XP_CONTRACT_ABI,
-            )
-            total_supply = contract.functions.totalSupply().call()
+            total_supply = 0
+            # Basic ERC20 totalSupply ABI
+            abi = [
+                {
+                    "constant": True,
+                    "inputs": [],
+                    "name": "totalSupply",
+                    "outputs": [{"name": "", "type": "uint256"}],
+                    "payable": False,
+                    "stateMutability": "view",
+                    "type": "function",
+                }
+            ]
+
+            for address in cfg.SETTINGS_TOKEN_ADDRESSES:
+                try:
+                    contract = w3.eth.contract(
+                        address=Web3.to_checksum_address(address.strip()), abi=abi
+                    )
+                    supply = contract.functions.totalSupply().call()
+                    total_supply += supply
+                    logger.info(
+                        f"Successfully fetched supply for token {address}: {supply}"
+                    )
+                except Exception as e:
+                    logger.error(f"Error fetching supply for token {address}: {e}")
+                    continue
+
             return float(total_supply) / (10**18)
 
         except Exception as e:
@@ -151,14 +175,13 @@ class Utils:
         Returns:
         int: The quorum value for Snapshot proposals.
         """
-        total_supply_sum = Utils.fetch_XP_total_supply()
-        if total_supply_sum is None:
+        total_supply = Utils.fetch_XP_total_supply()
+        if total_supply is None:
             logger.error("Failed to fetch total supply.")
             return None
 
-        web3 = Web3()
-        total_supply_in_ether = web3.from_wei(total_supply_sum, "ether")
-        quorum = (total_supply_in_ether * percentage) // 100
+        # Calculate percentage directly since total_supply is already in ether
+        quorum = int((total_supply * percentage) // 100)
         logger.info(f"{percentage}% of the total supply is {quorum}.")
         return quorum
 


### PR DESCRIPTION
**Whats new**
Updated logic to calculate fetch token supply and calculate quorum appropriately
Removed fallback of sepolia for network ID as this didn't make much sense

**How to test**
Refer to Readme for dev environment instructions.
observe logs

**Example logs from successful test**
```
BloomDiscordBot_1  | 13/01/25 01:56:15 - logger.logger - INFO - 153 - Successfully fetched supply for token 0x206d247F61cb82B9711318381cDb7Bc5039d2A2c: 56354705250000000000000000
BloomDiscordBot_1  | 13/01/25 01:56:16 - logger.logger - INFO - 153 - Successfully fetched supply for token 0x4cd06ada7d8564830018000d784c69bd542b1e6a: 2846774900000000000000000
BloomDiscordBot_1  | 13/01/25 01:56:17 - logger.logger - INFO - 153 - Successfully fetched supply for token 0x57d3a929fdc4faf1b35e7092d9dee7af097afb6a: 58955152090000000000000000
BloomDiscordBot_1  | 13/01/25 01:56:17 - logger.logger - INFO - 183 - 25% of the total supply is 29539158.
```