### PR TITLE
use values from the Config table to manage proposal IDs

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1,7 +1,3 @@
-[ID_START_VALUES]
-GOVERNANCE_ID = 2 
-BUDGET_ID = 28
-
 [DEV]
 snapshot_space = testnet-1.eth
 discord_vote_endtime = 120

--- a/config/config.py
+++ b/config/config.py
@@ -2,16 +2,12 @@ import os
 import configparser
 from logger.logger import logger
 
-CONFIG_ID_MAP: dict[str, str] = {"governance": "governance_id", "budget": "budget_id"}
 CONFIG_ABSOLUTE_PATH = "config/config.ini"
 
 config: configparser.ConfigParser = configparser.ConfigParser()
 config.read(CONFIG_ABSOLUTE_PATH)
 
 ENV = os.getenv("ENV", "DEV")
-
-current_governance_id: int = config.getint("ID_START_VALUES", "governance_id")
-current_budget_id: int = config.getint("ID_START_VALUES", "budget_id")
 
 SNAPSHOT_SPACE = config.get(ENV, "SNAPSHOT_SPACE")
 DISCORD_VOTE_ENDTIME = config.getint(ENV, "DISCORD_VOTE_ENDTIME")
@@ -29,41 +25,3 @@ SETTINGS_TOKEN_ADDRESSES = config.get(ENV, "SETTINGS_TOKEN_ADDRESSES").split(","
 
 PRIMARY_RPC_URL = os.getenv("PRIMARY_RPC_URL")
 SECONDARY_RPC_URL = os.getenv("SECONDARY_RPC_URL")
-
-
-def increment_config_id(
-    id_type: str, increment: int = +1, config: configparser.ConfigParser = config
-) -> None:
-    """
-    Increments the ID value for a given proposal type in the config file.
-
-    Note: Use typed id_types instead of using raw strings these can be imported from consts
-
-    Args:
-      id_type: A string specifying the ID type ('governance' or 'budget')
-      increment: An integer specifying how much to increment the ID by (default 1)
-      config: A ConfigParser instance (default uses config initialized here)
-
-    Returns:
-        None
-    """
-
-    id_type = id_type.lower()
-
-    if id_type not in CONFIG_ID_MAP:
-        err_msg = f"Invalid id_type: {id_type}"
-        logger.error(err_msg)
-        raise ValueError(err_msg)
-
-    key = CONFIG_ID_MAP[id_type]
-    new_value = int(config["ID_START_VALUES"][key]) + increment
-    config["ID_START_VALUES"][key] = str(new_value)
-
-    try:
-        with open(CONFIG_ABSOLUTE_PATH, "w") as f:
-            config.write(f)
-
-    except IOError as e:
-        err_msg = f"Error writing config file: {e}"
-        logger.error(err_msg)
-        raise Exception(err_msg, e)

--- a/consts/constants.py
+++ b/consts/constants.py
@@ -1,8 +1,6 @@
 """
 consts/constants.py contains constants used throughout the bot.
 
-CONFIG_ID_MAP: A dictionary containing the valid ids and keys that can be selected to be incremented or in rare cases decremented in the config.ini file.
-
 CONFIG_ABSOLUTE_PATH: The absolute path to the config.ini file.
 
 GENERAL_CHANNEL, GOVERNANCE_CHANNEL, GOVERNANCE_BUDGET_CHANNEL, GOVERNANCE_TALK_CHANNEL

--- a/consts/types.py
+++ b/consts/types.py
@@ -1,5 +1,0 @@
-# Valid typed ID typed to be imported
-# to avoid typos
-# this should be prefered over using raw strings
-GOVERNANCE_ID_TYPE: str = "governance"
-BUDGET_ID_TYPE: str = "budget"

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -125,18 +125,26 @@ class TaskManager:
                     draft_title = proposal_data["draft"]["title"]
                     proposal_type = proposal_data["draft"]["type"]
 
+                    config = db_service.get_config()
+
                     if proposal_type == "budget":
-                        current_budget_id = (
-                            cfg.config.getint("ID_START_VALUES", "budget_id") + 1
-                        )
-                        title = (
-                            f"Bloom Budget Proposal #{current_budget_id}: {draft_title}"
-                        )
+                        budget_id = config.get("next_budget_id", "")
+
+                        if not budget_id:
+                            logger.error("Budget ID is not set")
+                            continue
+
+                        title = f"Bloom Budget Proposal #{budget_id}: {draft_title}"
                     elif proposal_type == "governance":
-                        current_governance_id = (
-                            cfg.config.getint("ID_START_VALUES", "governance_id") + 1
+                        governance_id = config.get("next_governance_id", "")
+
+                        if not governance_id:
+                            logger.error("Governance ID is not set")
+                            continue
+
+                        title = (
+                            f"Bloom General Proposal #{governance_id}: {draft_title}"
                         )
-                        title = f"Bloom General Proposal #{current_governance_id}: {draft_title}"
                     else:
                         logger.error(f"Unknown proposal type: {proposal_type}")
                         continue
@@ -152,9 +160,13 @@ class TaskManager:
                     if proposal_url:
                         result_message += f"The vote passes! {random.choice(PROPOSAL_CONCLUSION_EMOJIS)}\n\nSnapshot proposal has been created: **{proposal_url}**"
                         if proposal_type == "budget":
-                            cfg.increment_config_id("budget", 1)
+                            db_service.set_config(
+                                "next_budget_id", str(int(budget_id) + 1)
+                            )
                         elif proposal_type == "governance":
-                            cfg.increment_config_id("governance", 1)
+                            db_service.set_config(
+                                "next_governance_id", str(int(governance_id) + 1)
+                            )
                     else:
                         result_message += f"The vote passes! {random.choice(PROPOSAL_CONCLUSION_EMOJIS)}"
                 else:


### PR DESCRIPTION
This change will be accompanied by a manual SQL query to insert appropriate key-value pairs.

DEV:
These values aren't relevant because we don't currently have a staging Snapshot space setup.
```sql
BEGIN;

INSERT INTO configs (key, value) VALUES ('next_governance_id', 1), ('next_budget_id', 1);

ROLLBACK;
```

PROD:
```sql
BEGIN;

INSERT INTO configs (key, value) VALUES ('next_governance_id', 3), ('next_budget_id', 29);

ROLLBACK;
```