### PR TITLE
request only intents needed for reading messages and slash commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,11 @@ from logger.logger import logger
 
 class Bot:
     def __init__(self):
-        self.bot = commands.Bot(command_prefix="/", intents=discord.Intents.all())
+        intents = discord.Intents.default()
+        intents.message_content = True  # Needed if your bot reads message content
+        intents.guilds = True  # Needed for basic guild/server operations
+        self.bot = commands.Bot(command_prefix="/", intents=intents)
+        # Learn more about Discord gateways intents here: https://discord.com/developers/docs/events/gateway#gateway-intents
 
         db_service = DatabaseService()
         self.bot.ongoing_votes = db_service.get_ongoing_votes()


### PR DESCRIPTION
Before merging this in we should be sure to update the `DISCORD_BOT_TOKEN` envar on the staging/prod deployments to the new Bloom Team bot token

`message_content` is needed to read the proposal drafts from users.
`guilds` is needed for slash commands

Intents are already toggled on [staging app](https://discord.com/developers/applications/1341904054531526716/bot) and [production app](https://discord.com/developers/applications/1341904282772832386/bot).